### PR TITLE
Fix duplicate LovyanGFX component registration

### DIFF
--- a/components/LovyanGFX/CMakeLists.txt
+++ b/components/LovyanGFX/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(LGFX_ROOT ${CMAKE_CURRENT_LIST_DIR}/lib)
+# Include the LovyanGFX ESP‑IDF configuration. This script sets the component
+# sources, include directories and registers the component with ESP‑IDF via the
+# internal `register_component` call. Calling `idf_component_register` here would
+# create the component twice and results in a CMake error.
 include(${LGFX_ROOT}/boards.cmake/esp-idf.cmake)
-
-idf_component_register(
-    SRCS ${COMPONENT_SRCS}
-    INCLUDE_DIRS "." ${COMPONENT_ADD_INCLUDEDIRS}
-    REQUIRES ${COMPONENT_REQUIRES}
-)


### PR DESCRIPTION
## Summary
- prevent double registration of the LovyanGFX component

## Testing
- `cmake -S . -B build` *(fails: include could not find project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_684ad0c3fc20832380ec73b8e3b73b65