### PR TITLE
Fix missing built-in font includes

### DIFF
--- a/components/LovyanGFX/lib/src/lgfx/v1/lgfx_fonts.cpp
+++ b/components/LovyanGFX/lib/src/lgfx/v1/lgfx_fonts.cpp
@@ -1178,6 +1178,7 @@ label_nextbyte: /// 次のデータを取得する;
     #include "../Fonts/Custom/DejaVu40.h"
     #include "../Fonts/Custom/DejaVu56.h"
     #include "../Fonts/Custom/DejaVu72.h"
+#endif
 
     #include "../Fonts/glcdfont.h"
     #include "../Fonts/Font16.h"
@@ -1188,7 +1189,6 @@ label_nextbyte: /// 次のデータを取得する;
     #include "../Fonts/Font8x8C64.h"
     #include "../Fonts/Ascii24x48.h"
     #include "../Fonts/Ascii8x16.h"
-#endif
 
     static constexpr uint8_t font0_info[]         = {  0, 255, 5 }; // start code, end code, width
     static constexpr uint8_t font8x8c64_info[]    = { 32, 143, 8 }; // start code, end code, width


### PR DESCRIPTION
## Summary
- ensure core font headers always included regardless of GFX font availability

## Testing
- `cmake .` *(fails: include could not find requested file)*

------
https://chatgpt.com/codex/tasks/task_e_684add22da6c832392d85ba1f55d54cf