### PR TITLE
Fix storage_service header inclusion

### DIFF
--- a/components/storage_service/storage_service.c
+++ b/components/storage_service/storage_service.c
@@ -2,7 +2,6 @@
 #include "esp_log.h"
 #include "esp_spiffs.h"
 #include "esp_vfs_fat.h"
-#include "sdmmc_host.h"
 #include "driver/sdmmc_host.h"
 #include "driver/sdmmc_defs.h"
 #include "sdmmc_cmd.h"


### PR DESCRIPTION
## Summary
- remove superfluous `sdmmc_host.h` include to avoid missing-header error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684adf1fc078832381f506f9c2ea1806