### PR TITLE
Fix OTA service build dependency

### DIFF
--- a/components/ota_service/CMakeLists.txt
+++ b/components/ota_service/CMakeLists.txt
@@ -1,4 +1,6 @@
-idf_component_register(SRCS "ota_service.c"
-                    INCLUDE_DIRS "."
-                    REQUIRES "esp_http_client" "esp_https_ota" "esp_ota_ops" "nvs_flash")
+idf_component_register(
+    SRCS "ota_service.c"
+    INCLUDE_DIRS "."
+    REQUIRES "esp_http_client" "esp_https_ota" "nvs_flash"
+)
 


### PR DESCRIPTION
## Summary
- fix OTA service CMake dependency list

## Testing
- `idf.py build` *(fails: `idf.py: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ae56b33b08323a239e6b98e38dbae