### PR TITLE
Fix build includes and dependencies

### DIFF
--- a/components/lvgl_port/CMakeLists.txt
+++ b/components/lvgl_port/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "lvgl_port.cpp"
-                    INCLUDE_DIRS "."
+                    INCLUDE_DIRS "." "../LovyanGFX"
                     REQUIRES "LovyanGFX" "gt911_touch" "lvgl")
 

--- a/components/lvgl_port/lvgl_port.cpp
+++ b/components/lvgl_port/lvgl_port.cpp
@@ -1,5 +1,6 @@
 #include "lvgl_port.h"
 #include "LovyanGFX.hpp"
+#include "LGFX_Config.hpp"
 #include "gt911.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"

--- a/components/lvgl_theme/lvgl_theme.c
+++ b/components/lvgl_theme/lvgl_theme.c
@@ -74,7 +74,7 @@ void lvgl_theme_init(void)
                                            lv_palette_main(LV_PALETTE_BLUE),
                                            lv_palette_main(LV_PALETTE_RED),
                                            false,
-                                           lv_font_default());
+                                           lv_font_get_default());
     lv_theme_set_apply_cb(th, theme_apply_cb);
     lv_display_set_theme(lv_display_get_default(), th);
 

--- a/components/ota_service/CMakeLists.txt
+++ b/components/ota_service/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "ota_service.c"
     INCLUDE_DIRS "."
-    REQUIRES "esp_http_client" "esp_https_ota" "nvs_flash"
+    REQUIRES "esp_http_client" "esp_https_ota" "nvs_flash" "app_update"
 )
 

--- a/components/ui_pages/console_debug_page/CMakeLists.txt
+++ b/components/ui_pages/console_debug_page/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "console_debug_page.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "lvgl")
+                    REQUIRES "lvgl" "i18n_service")
 

--- a/components/ui_pages/file_explorer_page/CMakeLists.txt
+++ b/components/ui_pages/file_explorer_page/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "file_explorer_page.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "lvgl" "storage_service")
+                    REQUIRES "lvgl" "storage_service" "i18n_service")
 

--- a/components/ui_pages/home_page/CMakeLists.txt
+++ b/components/ui_pages/home_page/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "home_page.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "lvgl")
+                    REQUIRES "lvgl" "i18n_service")
 

--- a/components/ui_pages/settings_page/CMakeLists.txt
+++ b/components/ui_pages/settings_page/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "settings_page.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "lvgl")
+                    REQUIRES "lvgl" "i18n_service")
 

--- a/components/ui_pages/wifi_bt_page/CMakeLists.txt
+++ b/components/ui_pages/wifi_bt_page/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "wifi_bt_page.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "lvgl")
+                    REQUIRES "lvgl" "i18n_service")
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+                    INCLUDE_DIRS "."
+                    REQUIRES "lvgl_port" "ui_manager" "lvgl_keyboard" "wifi_service" "bluetooth_service" "ota_service" "storage_service" "i18n_service" "lvgl_theme")
 


### PR DESCRIPTION
## Summary
- add missing dependencies for UI page components
- add `LGFX_Config.hpp` include to lvgl port
- update lvgl theme for LVGL 9
- declare OTA component dependency on app_update
- expose component dependencies for main build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ae822f2d88323b86913072a506800