### PR TITLE
Fix Wi-Fi and OTA services

### DIFF
--- a/components/ota_service/ota_service.c
+++ b/components/ota_service/ota_service.c
@@ -16,13 +16,17 @@ esp_err_t ota_service_start_update(const char *url)
 {
     ESP_LOGI(TAG, "Starting OTA update from %s", url);
 
-    esp_http_client_config_t config = {
+    esp_http_client_config_t http_config = {
         .url = url,
         .cert_pem = NULL, // No certificate for HTTP, provide if using HTTPS with custom certs
         .timeout_ms = 5000,
     };
 
-    esp_err_t ret = esp_https_ota(&config);
+    esp_https_ota_config_t ota_config = {
+        .http_config = &http_config,
+    };
+
+    esp_err_t ret = esp_https_ota(&ota_config);
     if (ret == ESP_OK) {
         ESP_LOGI(TAG, "OTA update successful, restarting...");
         esp_restart();

--- a/components/ui_pages/CMakeLists.txt
+++ b/components/ui_pages/CMakeLists.txt
@@ -5,4 +5,4 @@ idf_component_register(SRCS "home_page/home_page.c"
                      "console_debug_page/console_debug_page.c"
                      INCLUDE_DIRS "home_page" "wifi_bt_page" "file_explorer_page"
                                   "settings_page" "console_debug_page"
-                     REQUIRES lvgl storage_service)
+                     REQUIRES lvgl storage_service i18n_service)

--- a/components/wifi_service/wifi_service.c
+++ b/components/wifi_service/wifi_service.c
@@ -4,6 +4,7 @@
 #include "esp_log.h"
 #include "nvs_flash.h"
 #include "nvs.h"
+#include "esp_netif.h"
 #include "freertos/event_groups.h"
 #include <string.h>
 #include <stdlib.h>
@@ -29,7 +30,9 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
         xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
-        ESP_LOGI(TAG, "got ip:%s", ip4addr_ntoa(&event->ip_info.ip));
+        char ip_str[16];
+        esp_ip4addr_ntoa(&event->ip_info.ip, ip_str, sizeof(ip_str));
+        ESP_LOGI(TAG, "got ip:%s", ip_str);
         if (s_wifi_connect_cb) {
             s_wifi_connect_cb(ESP_OK);
         }


### PR DESCRIPTION
## Summary
- include esp_netif and use esp_ip4addr_ntoa in Wi-Fi event handler
- provide esp_https_ota_config_t when calling esp_https_ota
- link i18n_service component for UI pages

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aeb0c2a8c8323a01cb97b438705f3