### PR TITLE
Handle missing Bluedroid support

### DIFF
--- a/components/bluetooth_service/bluetooth_service.c
+++ b/components/bluetooth_service/bluetooth_service.c
@@ -1,10 +1,12 @@
 #include "bluetooth_service.h"
 #include "esp_log.h"
 #include "esp_bt.h"
+#include "esp_gatt_defs.h"
+
+#if CONFIG_BT_BLUEDROID_ENABLED
 #include "esp_gap_ble_api.h"
 #include "esp_gatts_api.h"
 #include "esp_bt_main.h"
-#include "esp_gatt_defs.h"
 
 static const char *TAG = "BLUETOOTH_SERVICE";
 
@@ -115,4 +117,23 @@ esp_err_t bluetooth_service_stop_advertising(void)
     return esp_ble_gap_stop_advertising();
 }
 
+#else // CONFIG_BT_BLUEDROID_ENABLED
+
+esp_err_t bluetooth_service_init(void)
+{
+    ESP_LOGW(TAG, "Bluedroid stack not enabled; Bluetooth service disabled");
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+esp_err_t bluetooth_service_start_advertising(void)
+{
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+esp_err_t bluetooth_service_stop_advertising(void)
+{
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+#endif // CONFIG_BT_BLUEDROID_ENABLED
 

--- a/components/bluetooth_service/bluetooth_service.h
+++ b/components/bluetooth_service/bluetooth_service.h
@@ -9,18 +9,30 @@ extern "C" {
 
 /**
  * @brief Initialize the Bluetooth service (BLE).
+ *
+ * When the Bluedroid stack is disabled, this function returns
+ * ESP_ERR_NOT_SUPPORTED and performs no initialization.
+ *
  * @return ESP_OK on success, otherwise an error code.
  */
 esp_err_t bluetooth_service_init(void);
 
 /**
  * @brief Start BLE advertising.
+ *
+ * If the Bluedroid stack is not enabled, this function returns
+ * ESP_ERR_NOT_SUPPORTED.
+ *
  * @return ESP_OK on success, otherwise an error code.
  */
 esp_err_t bluetooth_service_start_advertising(void);
 
 /**
  * @brief Stop BLE advertising.
+ *
+ * If the Bluedroid stack is not enabled, this function returns
+ * ESP_ERR_NOT_SUPPORTED.
+ *
  * @return ESP_OK on success, otherwise an error code.
  */
 esp_err_t bluetooth_service_stop_advertising(void);


### PR DESCRIPTION
## Summary
- guard Bluetooth service implementation behind `CONFIG_BT_BLUEDROID_ENABLED`
- provide stub functions when Bluedroid is disabled
- document behaviour in the Bluetooth service API

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684af8b2b3908323a03ba67b0f7edc52