### PR TITLE
Fix bluetooth service TAG

### DIFF
--- a/components/bluetooth_service/bluetooth_service.c
+++ b/components/bluetooth_service/bluetooth_service.c
@@ -3,12 +3,12 @@
 #include "esp_bt.h"
 #include "esp_gatt_defs.h"
 
+static const char *TAG = "BLUETOOTH_SERVICE";
+
 #if CONFIG_BT_BLUEDROID_ENABLED
 #include "esp_gap_ble_api.h"
 #include "esp_gatts_api.h"
 #include "esp_bt_main.h"
-
-static const char *TAG = "BLUETOOTH_SERVICE";
 
 // Declare a GATT server interface
 static esp_gatt_if_t gatts_if;


### PR DESCRIPTION
## Summary
- ensure TAG is defined regardless of Bluedroid configuration so fallback builds compile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684afb631ea883238a963f608bc0aafb