### PR TITLE
Fix bluetooth build when Bluedroid disabled

### DIFF
--- a/components/bluetooth_service/bluetooth_service.c
+++ b/components/bluetooth_service/bluetooth_service.c
@@ -1,7 +1,11 @@
 #include "bluetooth_service.h"
 #include "esp_log.h"
+
+#if CONFIG_BT_BLUEDROID_ENABLED
 #include "esp_bt.h"
 #include "esp_gatt_defs.h"
+
+#endif
 
 static const char *TAG = "BLUETOOTH_SERVICE";
 


### PR DESCRIPTION
## Summary
- guard esp_bt includes under CONFIG_BT_BLUEDROID_ENABLED

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bfdf474fc8323a92855025460e79e