### PR TITLE
Add dynamic screen and touch detection

### DIFF
--- a/main/expander_ch422g.c
+++ b/main/expander_ch422g.c
@@ -4,8 +4,96 @@
  */
 
 #include "expander_ch422g.h"
+#include "driver/i2c.h"
+#include "esp_log.h"
 
-void expander_ch422g_init(void)
+/** Nom du module */
+static const char *TAG = "ch422g";
+
+/* Adresses I2C des "registres" du CH422G */
+#define CH422G_REG_WR_SET (0x48 >> 1)
+#define CH422G_REG_WR_OC  (0x46 >> 1)
+#define CH422G_REG_WR_IO  (0x70 >> 1)
+#define CH422G_REG_RD_IO  (0x4D >> 1)
+
+/* Valeurs par defaut */
+#define CH422G_WR_SET_DEFAULT 0x01
+#define CH422G_WR_OC_DEFAULT  0x0F
+#define CH422G_WR_IO_DEFAULT  0xFF
+
+/* Fonctions internes d'acces I2C */
+static esp_err_t ch422g_write_reg(const expander_ch422g_t *dev, uint8_t reg, uint8_t val)
 {
-    // TODO: initialiser le module expander_ch422g
+    return i2c_master_write_to_device(dev->port, reg, &val, 1, pdMS_TO_TICKS(50));
+}
+
+static esp_err_t ch422g_read_reg(const expander_ch422g_t *dev, uint8_t reg, uint8_t *val)
+{
+    return i2c_master_read_from_device(dev->port, reg, val, 1, pdMS_TO_TICKS(50));
+}
+
+bool expander_ch422g_init(expander_ch422g_t *dev, int port)
+{
+    if (!dev) {
+        return false;
+    }
+
+    dev->port    = port;
+    dev->address = CH422G_REG_WR_SET; /* premiere adresse connue */
+    dev->wr_set  = CH422G_WR_SET_DEFAULT;
+    dev->wr_oc   = CH422G_WR_OC_DEFAULT;
+    dev->wr_io   = CH422G_WR_IO_DEFAULT;
+
+    /* tentative d'ecriture pour verifier la presence du composant */
+    esp_err_t ret = ch422g_write_reg(dev, CH422G_REG_WR_SET, dev->wr_set);
+    if (ret != ESP_OK) {
+        dev->present = false;
+        ESP_LOGW(TAG, "CH422G absent");
+        return false;
+    }
+
+    /* configuration par defaut */
+    ch422g_write_reg(dev, CH422G_REG_WR_OC,  dev->wr_oc);
+    ch422g_write_reg(dev, CH422G_REG_WR_IO,  dev->wr_io);
+
+    dev->present = true;
+    ESP_LOGI(TAG, "CH422G detecte sur le port %d", port);
+    return true;
+}
+
+esp_err_t expander_ch422g_set_all_output(expander_ch422g_t *dev)
+{
+    if (!dev || !dev->present) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    dev->wr_set |= 0x01; /* BIT_IO_OE */
+    return ch422g_write_reg(dev, CH422G_REG_WR_SET, dev->wr_set);
+}
+
+esp_err_t expander_ch422g_write(expander_ch422g_t *dev, uint16_t value)
+{
+    if (!dev || !dev->present) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    uint8_t oc = (value >> 8) & 0x0F;
+    uint8_t io = value & 0xFF;
+
+    esp_err_t ret1 = ch422g_write_reg(dev, CH422G_REG_WR_OC, oc);
+    esp_err_t ret2 = ch422g_write_reg(dev, CH422G_REG_WR_IO, io);
+
+    if (ret1 == ESP_OK) dev->wr_oc = oc;
+    if (ret2 == ESP_OK) dev->wr_io = io;
+
+    return (ret1 != ESP_OK) ? ret1 : ret2;
+}
+
+esp_err_t expander_ch422g_read(expander_ch422g_t *dev, uint8_t *value)
+{
+    if (!dev || !dev->present || !value) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return ch422g_read_reg(dev, CH422G_REG_RD_IO, value);
 }

--- a/main/expander_ch422g.h
+++ b/main/expander_ch422g.h
@@ -10,7 +10,45 @@
 extern "C" {
 #endif
 
-void expander_ch422g_init(void);
+#include <stdint.h>
+#include <stdbool.h>
+#include "esp_err.h"
+
+/**
+ * @brief Structure de gestion du composant CH422G
+ */
+typedef struct {
+    bool       present;   /**< Vrai si l'extension est détectée */
+    uint8_t    address;   /**< Adresse I2C utilisée pour les registres */
+    int        port;      /**< Port I2C associé */
+    uint8_t    wr_set;    /**< Copie locale du registre WR_SET */
+    uint8_t    wr_oc;     /**< Copie locale du registre WR_OC */
+    uint8_t    wr_io;     /**< Copie locale du registre WR_IO */
+} expander_ch422g_t;
+
+/**
+ * @brief Initialise l'extension et détecte sa présence
+ *
+ * @param dev  Structure de périphérique à initialiser
+ * @param port Port I2C à utiliser
+ * @return true si l'extension est détectée
+ */
+bool expander_ch422g_init(expander_ch422g_t *dev, int port);
+
+/**
+ * @brief Configure tous les ports de l'extension en sortie push-pull
+ */
+esp_err_t expander_ch422g_set_all_output(expander_ch422g_t *dev);
+
+/**
+ * @brief Écrit un mot de 16 bits sur les sorties
+ */
+esp_err_t expander_ch422g_write(expander_ch422g_t *dev, uint16_t value);
+
+/**
+ * @brief Lit l'état des entrées
+ */
+esp_err_t expander_ch422g_read(expander_ch422g_t *dev, uint8_t *value);
 
 #ifdef __cplusplus
 }

--- a/main/lcd_manager.c
+++ b/main/lcd_manager.c
@@ -4,8 +4,78 @@
  */
 
 #include "lcd_manager.h"
+#include "touch_manager.h"
+#include "expander_ch422g.h"
+#include "driver/i2c.h"
+#include "esp_log.h"
+#include <string.h>
+
+/** Nom du module pour les logs */
+static const char *TAG = "lcd_manager";
+
+/** Configuration LCD détectée */
+static lcd_config_t s_lcd_cfg;
+
+/**
+ * @brief Initialisation du bus I2C utilisé pour la détection
+ */
+static esp_err_t lcd_i2c_init(void)
+{
+    static bool init = false;
+    if (init) {
+        return ESP_OK;
+    }
+
+    i2c_config_t conf = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = LCD_MANAGER_I2C_SDA,
+        .scl_io_num = LCD_MANAGER_I2C_SCL,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = LCD_MANAGER_I2C_FREQ_HZ,
+        .clk_flags = 0,
+    };
+
+    esp_err_t ret = i2c_param_config(LCD_MANAGER_I2C_PORT, &conf);
+    if (ret == ESP_OK) {
+        ret = i2c_driver_install(LCD_MANAGER_I2C_PORT, conf.mode, 0, 0, 0);
+    }
+
+    if (ret == ESP_OK) {
+        init = true;
+    }
+
+    return ret;
+}
 
 void lcd_manager_init(void)
 {
-    // TODO: initialiser le module lcd_manager
+    memset(&s_lcd_cfg, 0, sizeof(s_lcd_cfg));
+
+    lcd_i2c_init();
+
+    expander_ch422g_t expander;
+    bool has_expander = expander_ch422g_init(&expander, LCD_MANAGER_I2C_PORT);
+
+    if (has_expander) {
+        s_lcd_cfg.model  = LCD_MODEL_WAVESHARE_5B;
+        s_lcd_cfg.width  = 1024;
+        s_lcd_cfg.height = 600;
+        ESP_LOGI(TAG, "Expander CH422G detecte - ecran 5B 1024x600");
+    } else {
+        s_lcd_cfg.model  = LCD_MODEL_WAVESHARE_7INCH;
+        s_lcd_cfg.width  = 800;
+        s_lcd_cfg.height = 480;
+        ESP_LOGI(TAG, "Aucun expander detecte - ecran 7'' 800x480");
+    }
+
+    /* Detection du controleur tactile */
+    touch_manager_init();
+
+    ESP_LOGI(TAG, "LCD configure: %ux%u", s_lcd_cfg.width, s_lcd_cfg.height);
+}
+
+const lcd_config_t *lcd_manager_get_config(void)
+{
+    return &s_lcd_cfg;
 }

--- a/main/lcd_manager.h
+++ b/main/lcd_manager.h
@@ -10,7 +10,44 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * @brief Modèles d'écran gérés
+ */
+typedef enum {
+    LCD_MODEL_UNKNOWN = 0,      /**< Modèle non détecté */
+    LCD_MODEL_WAVESHARE_7INCH,  /**< Ecran Waveshare 7" 800x480 */
+    LCD_MODEL_WAVESHARE_5B      /**< Ecran Waveshare 5B 1024x600 */
+} lcd_model_t;
+
+/**
+ * @brief Configuration détectée de l'écran
+ */
+typedef struct {
+    lcd_model_t model;  /**< Type de dalle LCD */
+    uint16_t    width;  /**< Largeur en pixels */
+    uint16_t    height; /**< Hauteur en pixels */
+} lcd_config_t;
+
+/** I2C utilisé pour la détection LCD/tactile */
+#define LCD_MANAGER_I2C_PORT     I2C_NUM_0
+#define LCD_MANAGER_I2C_SDA      18
+#define LCD_MANAGER_I2C_SCL      17
+#define LCD_MANAGER_I2C_FREQ_HZ  400000
+
+/**
+ * @brief Initialise la détection et la configuration de l'écran
+ */
 void lcd_manager_init(void);
+
+/**
+ * @brief Récupère la configuration détectée
+ *
+ * @return Pointeur vers la structure de configuration (valide après init)
+ */
+const lcd_config_t *lcd_manager_get_config(void);
 
 #ifdef __cplusplus
 }

--- a/main/touch_manager.c
+++ b/main/touch_manager.c
@@ -4,8 +4,41 @@
  */
 
 #include "touch_manager.h"
+#include "lcd_manager.h"
+#include "driver/i2c.h"
+#include "esp_log.h"
+
+/** Nom du module pour les logs */
+static const char *TAG = "touch_manager";
+
+/** Contrôleur détecté */
+static touch_driver_t s_driver = TOUCH_DRIVER_UNKNOWN;
+
+/**
+ * @brief Probe rapide d'une adresse I2C
+ */
+static bool probe_addr(int port, uint8_t addr)
+{
+    return i2c_master_write_read_device(port, addr, NULL, 0, NULL, 0, pdMS_TO_TICKS(50)) == ESP_OK;
+}
 
 void touch_manager_init(void)
 {
-    // TODO: initialiser le module touch_manager
+    int port = LCD_MANAGER_I2C_PORT;
+
+    if (probe_addr(port, 0x5d) || probe_addr(port, 0x14)) {
+        s_driver = TOUCH_DRIVER_GT911;
+        ESP_LOGI(TAG, "Controleur tactile GT911 detecte");
+    } else if (probe_addr(port, 0x38)) {
+        s_driver = TOUCH_DRIVER_FT5436;
+        ESP_LOGI(TAG, "Controleur tactile FT5436 detecte");
+    } else {
+        s_driver = TOUCH_DRIVER_UNKNOWN;
+        ESP_LOGW(TAG, "Aucun controleur tactile detecte");
+    }
+}
+
+touch_driver_t touch_manager_get_driver(void)
+{
+    return s_driver;
 }

--- a/main/touch_manager.h
+++ b/main/touch_manager.h
@@ -10,7 +10,26 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
+
+/**
+ * @brief Types de contrôleurs tactiles supportés
+ */
+typedef enum {
+    TOUCH_DRIVER_UNKNOWN = 0, /**< Aucun contrôleur détecté */
+    TOUCH_DRIVER_GT911,       /**< Contrôleur Goodix GT911 */
+    TOUCH_DRIVER_FT5436       /**< Contrôleur FocalTech FT5436 */
+} touch_driver_t;
+
+/**
+ * @brief Initialise la détection du contrôleur tactile
+ */
 void touch_manager_init(void);
+
+/**
+ * @brief Renvoie le type de contrôleur détecté
+ */
+touch_driver_t touch_manager_get_driver(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- implement LCD auto-detection via CH422G expander
- support GT911 and FT5436 touch controllers
- expose LCD configuration and detected touch driver
- add CH422G I/O expander driver

## Testing
- `sh scripts/test_io.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c470ed9dc83238aeaeca0d219d6a5